### PR TITLE
Exporting types

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -1,1 +1,2 @@
 export * from "./nvidia-smi";
+export * from "./types";


### PR DESCRIPTION
Types are not exported when used as a library, making it more difficult to deal with than necessary.